### PR TITLE
Add GA4 analytics tracking

### DIFF
--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -43,6 +43,50 @@ export default function RootLayout({
             gtag('config', '${GA_ID}', { tool_name: '${TOOL_NAME}' });
           `}
         </Script>
+        <Script id="engagement-tracking" strategy="afterInteractive">
+          {`
+            (function() {
+              var TOOL_NAME = '${TOOL_NAME}';
+              if (typeof window === 'undefined' || !window.gtag) return;
+
+              var scrollFired = {};
+              window.addEventListener('scroll', function() {
+                var docHeight = document.documentElement.scrollHeight - window.innerHeight;
+                if (docHeight <= 0) return;
+                var pct = Math.floor((window.scrollY / docHeight) * 100);
+                [25, 50, 75, 100].forEach(function(m) {
+                  if (pct >= m && !scrollFired[m]) {
+                    scrollFired[m] = true;
+                    window.gtag('event', 'scroll_depth', { percent: m, tool_name: TOOL_NAME });
+                  }
+                });
+              }, { passive: true });
+
+              [30, 60, 120, 300].forEach(function(sec) {
+                setTimeout(function() {
+                  if (document.visibilityState !== 'hidden') {
+                    window.gtag('event', 'time_on_tool', { seconds: sec, tool_name: TOOL_NAME });
+                  }
+                }, sec * 1000);
+              });
+
+              document.addEventListener('click', function(e) {
+                var link = e.target && e.target.closest ? e.target.closest('a') : null;
+                if (!link || !link.href) return;
+                try {
+                  var url = new URL(link.href, window.location.origin);
+                  if (url.hostname && url.hostname !== window.location.hostname) {
+                    window.gtag('event', 'outbound_click', {
+                      url: link.href,
+                      target_hostname: url.hostname,
+                      tool_name: TOOL_NAME
+                    });
+                  }
+                } catch (err) {}
+              });
+            })();
+          `}
+        </Script>
       </head>
       <body className={`${inter.variable} font-sans antialiased`}>
         <Header />

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -10,7 +10,7 @@ const inter = Inter({
   display: "swap",
 });
 
-const GA_ID = "G-91M4529HE7";
+const GA_ID = "G-2YHG89FY0N";
 const TOOL_NAME = "crossroads";
 
 export const metadata: Metadata = {

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
 import { Inter } from "next/font/google";
+import Script from "next/script";
 import "./globals.css";
 import Header from "@/components/Header";
 
@@ -8,6 +9,9 @@ const inter = Inter({
   subsets: ["latin"],
   display: "swap",
 });
+
+const GA_ID = "G-91M4529HE7";
+const TOOL_NAME = "crossroads";
 
 export const metadata: Metadata = {
   title: "Crossroads | PolicyEngine",
@@ -26,6 +30,20 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en">
+      <head>
+        <Script
+          src={`https://www.googletagmanager.com/gtag/js?id=${GA_ID}`}
+          strategy="afterInteractive"
+        />
+        <Script id="gtag-init" strategy="afterInteractive">
+          {`
+            window.dataLayer = window.dataLayer || [];
+            function gtag(){dataLayer.push(arguments);}
+            gtag('js', new Date());
+            gtag('config', '${GA_ID}', { tool_name: '${TOOL_NAME}' });
+          `}
+        </Script>
+      </head>
       <body className={`${inter.variable} font-sans antialiased`}>
         <Header />
         <main>{children}</main>


### PR DESCRIPTION
## Summary
- Adds GA4 tracking (shared org ID `G-2YHG89FY0N`) with `tool_name=crossroads` on all events so this tool rolls up into the PolicyEngine-wide analytics dashboard.
- Events: pageview, `scroll_depth` (25/50/75/100%), `time_on_tool` (30/60/120/300s, visible tabs only), `outbound_click` (any link off this host).

## Follow-ups (out of scope)
- Tool-specific events: calculator submit, input changes, share/embed CTAs

## Test plan
- [ ] `gtag/js` loads in browser network tab
- [ ] `tool_name: crossroads` appears in GA4 DebugView on pageview
- [ ] Scroll to bottom: `scroll_depth` events fire at 25/50/75/100
- [ ] Wait 30s+ on the page: `time_on_tool` events fire
- [ ] Click an external link: `outbound_click` event fires

🤖 Generated with [Claude Code](https://claude.com/claude-code)